### PR TITLE
WEB-33990: Backpressure for MsbResponderActors

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+msbConfig {
+  responder {
+    # The maximum time that a responder will block before giving up on a the MsbResponderActor.handleRequest() logic
+    request-handling-timeout: 5 minutes
+  }
+}

--- a/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbAdapterFactory.java
+++ b/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbAdapterFactory.java
@@ -1,0 +1,46 @@
+package io.github.tcdl.msb.mock.adapterfactory;
+
+import io.github.tcdl.msb.adapters.AdapterFactory;
+import io.github.tcdl.msb.adapters.ConsumerAdapter;
+import io.github.tcdl.msb.adapters.MessageHandlerInvokeStrategy;
+import io.github.tcdl.msb.adapters.ProducerAdapter;
+import io.github.tcdl.msb.config.MsbConfig;
+import io.github.tcdl.msb.impl.SimpleMessageHandlerInvokeStrategyImpl;
+
+/**
+ * This class is for testing purposes only and is intended as a more multithreading friendly alternative to
+ * {@link TestMsbAdapterFactory}.
+ */
+public class SafeTestMsbAdapterFactory implements AdapterFactory {
+
+    private SafeTestMsbStorageForAdapterFactory storage = new SafeTestMsbStorageForAdapterFactory();
+
+    @Override
+    public void init(MsbConfig msbConfig) {
+
+    }
+
+    @Override
+    public ProducerAdapter createProducerAdapter(String namespace) {
+        TestMsbProducerAdapter producerAdapter = new TestMsbProducerAdapter(namespace, storage);
+        storage.addProducerAdapter(namespace, producerAdapter);
+        return producerAdapter;
+    }
+
+    @Override
+    public ConsumerAdapter createConsumerAdapter(String namespace, boolean isResponseTopic) {
+        SafeTestMsbConsumerAdapter consumerAdapter = new SafeTestMsbConsumerAdapter(namespace, storage);
+        storage.addConsumerAdapter(namespace, consumerAdapter);
+        return consumerAdapter;
+    }
+
+    @Override
+    public MessageHandlerInvokeStrategy createMessageHandlerInvokeStrategy(String topic) {
+        return new SimpleMessageHandlerInvokeStrategyImpl();
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbConsumerAdapter.java
+++ b/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbConsumerAdapter.java
@@ -1,0 +1,71 @@
+package io.github.tcdl.msb.mock.adapterfactory;
+
+import io.github.tcdl.msb.acknowledge.AcknowledgementHandlerInternal;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.newSetFromMap;
+
+public class SafeTestMsbConsumerAdapter extends TestMsbConsumerAdapter {
+
+    private final Set<RawMessageHandler> rawMessageHandlers = newSetFromMap(new ConcurrentHashMap<>());
+
+    public SafeTestMsbConsumerAdapter(String namespace, TestMsbStorageForAdapterFactory storage) {
+        super(namespace, storage);
+    }
+
+    @Override
+    public void subscribe(RawMessageHandler onMessageHandler) {
+        rawMessageHandlers.add(onMessageHandler);
+    }
+
+    @Override
+    public void pushTestMessage(String jsonMessage) {
+        AcknowledgementHandlerInternal ackHandler = new AcknowledgementHandlerInternalStub();
+        rawMessageHandlers.forEach(handler -> handler.onMessage(jsonMessage, ackHandler));
+    }
+
+    private static class AcknowledgementHandlerInternalStub implements AcknowledgementHandlerInternal {
+
+        @Override
+        public void autoConfirm() {
+
+        }
+
+        @Override
+        public void autoReject() {
+
+        }
+
+        @Override
+        public void autoRetry() {
+
+        }
+
+        @Override
+        public void setAutoAcknowledgement(boolean b) {
+
+        }
+
+        @Override
+        public boolean isAutoAcknowledgement() {
+            return false;
+        }
+
+        @Override
+        public void confirmMessage() {
+
+        }
+
+        @Override
+        public void retryMessage() {
+
+        }
+
+        @Override
+        public void rejectMessage() {
+
+        }
+    }
+}

--- a/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbStorageForAdapterFactory.java
+++ b/src/test/java/io/github/tcdl/msb/mock/adapterfactory/SafeTestMsbStorageForAdapterFactory.java
@@ -1,0 +1,56 @@
+package io.github.tcdl.msb.mock.adapterfactory;
+
+import io.github.tcdl.msb.api.MsbContext;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SafeTestMsbStorageForAdapterFactory extends TestMsbStorageForAdapterFactory {
+    private final ConcurrentHashMap<String, TestMsbConsumerAdapter> consumers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TestMsbProducerAdapter> producers = new ConcurrentHashMap<>();
+
+    @Override
+    public void connect(MsbContext otherContext) {
+        throw new UnsupportedOperationException("don't think we need this.");
+    }
+
+    @Override
+    void addProducerAdapter(String namespace, TestMsbProducerAdapter adapter) {
+        producers.put(namespace, adapter);
+    }
+
+    @Override
+    void addConsumerAdapter(String namespace, TestMsbConsumerAdapter adapter) {
+        consumers.put(namespace, adapter);
+    }
+
+    @Override
+    void addPublishedTestMessage(String namespace, String jsonMessage) {
+        // there's no need for this to do anything
+    }
+
+    @Override
+    public synchronized void cleanup() {
+        consumers.clear();
+        producers.clear();
+    }
+
+    @Override
+    public void publishIncomingMessage(String namespace, String jsonMessage) {
+        TestMsbConsumerAdapter consumerAdapter = consumers.get(namespace);
+        if(consumerAdapter != null) {
+            consumerAdapter.pushTestMessage(jsonMessage);
+        }
+    }
+
+    @Override
+    public List<String> getOutgoingMessages(String namespace) {
+        throw new UnsupportedOperationException("don't think we need this.");
+    }
+
+    @Override
+    public String getOutgoingMessage(String namespace) {
+        throw new UnsupportedOperationException("don't think we need this.");
+    }
+
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -17,11 +17,13 @@ test {
     # Do not specify this property to assert that we successfully fall back to msb-java's default config.
     # validateMessage = true
 
-    brokerAdapterFactory = "io.github.tcdl.msb.mock.adapterfactory.TestMsbAdapterFactory" # in memory broker
+    brokerAdapterFactory = "io.github.tcdl.msb.mock.adapterfactory.SafeTestMsbAdapterFactory" # in memory broker
 
     # Broker Adapter Defaults
     brokerConfig = {
     }
+
+
   }
 
   msbTargets = [

--- a/src/test/scala/io/github/tcdl/msb/MsbResponderActorTest.scala
+++ b/src/test/scala/io/github/tcdl/msb/MsbResponderActorTest.scala
@@ -1,51 +1,105 @@
 package io.github.tcdl.msb
 
+import java.util.UUID
+
 import scala.concurrent.duration._
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 import org.scalatest.concurrent.Eventually
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.testkit.TestKit
-import io.github.tcdl.msb.api.{MessageContext, RequestOptions}
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestKit}
+import io.github.tcdl.msb.api.{MessageContext, MsbContext, RequestOptions}
 import io.github.tcdl.msb.api.message.payload.RestPayload
 
+import scala.concurrent.{Await, Future, Promise, blocking}
+
 class MsbResponderActorTest extends TestKit(ActorSystem("msb-actor-test"))
-  with WordSpecLike with Matchers with Eventually {
+  with WordSpecLike with Matchers with Eventually with ImplicitSender {
 
   import org.scalatest.OptionValues._
+  import system.dispatcher
 
-  val msbcontext = Msb(system).context
-  val namespace = "msb-akka:responder-test"
+  val msbContext: MsbContext = Msb(system).context
+  val namespace: String = "msb-akka:responder-test"
 
-  val responder = system.actorOf(Props(new MsbResponderActorForTest()))
+  val responder: ActorRef = system.actorOf(Props(new MsbResponderActorForTest()))
 
   "An MsbResponderActor" when {
 
     "replying" should {
       "pass the reply to the requester" in {
         var pong: Option[String] = None
-        val requestResponse = new RequestOptions.Builder().withWaitForResponses(1).build()
-
-        msbcontext.getObjectFactory.createRequester(namespace, requestResponse, classOf[RestPayload[Any, Any, Any, String]])
-          .onResponse { (p: RestPayload[Any, Any, Any, String], _: MessageContext) => pong = Some(p.getBody) }
-          .publish(new RestPayload.Builder().withBody("ping").build(), null.asInstanceOf[String])
+        sendRequest("ping", (p, _) => pong = Some(p.getBody))
 
         eventually(timeout(5.seconds)) {
           pong.value shouldBe "pong"
         }
       }
     }
+
+    "the request invokes asynchronous processing" should {
+      "not take in all the messages at once" in {
+        var promises: List[Promise[String]] = List()
+
+        for(_ <- 1 to 5) {
+          val promise = Promise[String]
+          sendRequest("async", (p, _) => promise.success(p.getBody))
+          promises ::= promise
+        }
+
+        Await.ready(Future.sequence(promises.map(_.future)), 30.seconds)
+
+        responder ! "max"
+        val actualMaxRunning = expectMsgType[Int]
+
+        // The SafeTestMsbAdapterFactory used by this test is inherently single-threaded, so if it blocks while
+        // waiting for the handling to finish, there should never be more than one handler running at the same time.
+        assert(actualMaxRunning <= 1, s"No more than 1 jobs should've run in parallel, but was $actualMaxRunning")
+      }
+    }
   }
 
 
+  private def sendRequest(body: String,
+                          onResponse: (RestPayload[Any, Any, Any, String], MessageContext) => Unit,
+                          requestResponse: RequestOptions = new RequestOptions.Builder().withWaitForResponses(1).build()) = {
+
+    msbContext.getObjectFactory
+      .createRequester(namespace, requestResponse, classOf[RestPayload[Any, Any, Any, String]])
+      .onResponse(onResponse)
+      .publish(new RestPayload.Builder().withBody(body).build(), null.asInstanceOf[String])
+  }
+
   private class MsbResponderActorForTest extends MsbResponderActor {
 
-	  override val namespace = MsbResponderActorTest.this.namespace
+	  override val namespace: String = MsbResponderActorTest.this.namespace
+    var running: Map[UUID, Promise[Unit]] = Map()
+    var maxRunning: Int = 0
 
-    override def handleRequest = {
-      case (p, replyTo) if p.bodyAs[String].contains("ping") => replyTo ! response("pong")
+    override def handleRequest: PartialFunction[(MsbModel.Request, Responder), Any] = {
+      case (p, replyTo) if p.bodyAs[String].contains("ping") =>
+        replyTo ! response("pong")
+
+      case (p, replyTo) if p.bodyAs[String].contains("async") =>
+        val id = UUID.randomUUID()
+        running += (id -> Promise())
+        if(running.size > maxRunning) maxRunning = running.size
+        context.system.scheduler.scheduleOnce(100.millis, self, (id, replyTo))(context.dispatcher)
+
+        running(id).future
     }
 
+    override def aroundReceive(receive: Receive, msg: Any): Unit = {
+      msg match {
+        case (id: UUID, replyTo: Responder) =>
+          val promise = running(id)
+          running -= id
+          promise.success(())
+          replyTo ! response("done")
+
+        case "max" => sender ! maxRunning
+        case _ => super.aroundReceive(receive, msg)
+      }
+    }
   }
 }


### PR DESCRIPTION
The MsbResponderActor calls a handleRequest method which is implemented
by the service. This service can then choose to either return an object
or a Future. If it returns a Future, the MsbResponderActor will detect
it and wait for its completion, before returning from the
io.github.tcdl.msb.api.ResponderServer.RequestHandler#process method.