### PR TITLE
Smoothing out some rough edges

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,3 +4,18 @@ msbConfig {
     request-handling-timeout: 5 minutes
   }
 }
+// The thread pool that will be used for posting publish messages to the bus.
+msb-publishing-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  throughput = 1
+
+  thread-pool-executor {
+    core-pool-size-min = 2
+    core-pool-size-factor = 2.0
+    core-pool-size-max = 4
+    max-pool-size-min = 2
+    max-pool-size-factor = 2.0
+    max-pool-size-max = 8
+  }
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,6 +1,5 @@
-msbConfigPath = "test"
 
-test {
+msb-test-config {
   msbConfig {
 
     # Service Details

--- a/src/test/scala/io/github/tcdl/msb/MsbRequesterTest.scala
+++ b/src/test/scala/io/github/tcdl/msb/MsbRequesterTest.scala
@@ -2,7 +2,6 @@ package io.github.tcdl.msb
 
 import java.util.UUID
 
-import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import io.github.tcdl.msb.MsbModel.{Request, Response}
 import io.github.tcdl.msb.MsbRequester.{PublishEnded, TargetNotConfigured}
@@ -12,7 +11,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpecLike, Matchers}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
 
-class MsbRequesterTest extends TestKit(ActorSystem("msb-requester-test")) with ImplicitSender
+class MsbRequesterTest extends TestKit(MsbTests.actorSystem) with ImplicitSender
   with FlatSpecLike with Matchers
   with BeforeAndAfter
   with BeforeAndAfterAll {

--- a/src/test/scala/io/github/tcdl/msb/MsbResponderActorTest.scala
+++ b/src/test/scala/io/github/tcdl/msb/MsbResponderActorTest.scala
@@ -13,7 +13,7 @@ import io.github.tcdl.msb.api.message.payload.RestPayload
 
 import scala.concurrent.{Await, Future, Promise, blocking}
 
-class MsbResponderActorTest extends TestKit(ActorSystem("msb-actor-test"))
+class MsbResponderActorTest extends TestKit(MsbTests.actorSystem)
   with WordSpecLike with Matchers with Eventually with BeforeAndAfterEach
   with ImplicitSender {
 

--- a/src/test/scala/io/github/tcdl/msb/MsbTests.scala
+++ b/src/test/scala/io/github/tcdl/msb/MsbTests.scala
@@ -1,0 +1,10 @@
+package io.github.tcdl.msb
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+
+object MsbTests {
+  def actorSystem: ActorSystem = ActorSystem("msb-requester-test",
+    config = ConfigFactory.parseString("""msbConfigPath = "msb-test-config"""").resolve()
+  )
+}


### PR DESCRIPTION
* Removes redundant log statement
* Hides msb-akka's test config when the project is used as a dependency
* Defines a seperate dispatcher for the MsbRequester actors to use for
the blocking io.github.tcdl.msb.api.Requester#publish() call.