### PR TITLE
CONTENT-1457: Enable retries on timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,16 @@ scala:
 - 2.11.8
 - 2.12.7
 jdk:
-- oraclejdk8
+- openjdk8
 script:
   # Your normal script
-  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M clean coverage test
+  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M clean coverage test &&
+    sbt coverageAggregate
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
-after_success: "sbt coveralls"
+after_success: "sbt coverageReport coveralls"
 env:
   coveralls:
     secure: c2DZAgGBPcUNheRZZjmwZlzshOb9bRiDdEtNBm8BCBmySBTlru+ozghxJFBSxSVJapYlQ5T8VukKjfvn/t++Iq2hjVXZZcP4JDfAhTqiQpvjHriqwhsNUPNEc82nj9yZcm6WYshwB+ra8YVq1IIkDQAri2F5eQAiOIwHqWBo6uGw+gcgKv+xEv8B36jgOm2s8a7cQLeBkotp+ZyukbcFlh7kJSjvyUxRTTtJJQnUlynPIZWP7o6T2gjLFvLJFU8Fjy1eJ0p+T8h0NVmU4AjBfsgz/dW+LCeKltJRka7An5TW2+3whofUC7kYHchFSQktCherbHb45RPC8Nzff27vM6+MqTdl3W9rn4Grje3BM+y1XJWTllcrM0y2VRDX+2ZYXxg0Z8AQhJFRaQaYfZdN2U0MjkGF7CMP7vcy8nZRxL/ScOrkAsCKSWzW4aTFmgTSuV5s7m0ZVO5LdJ4wP3OLSoXvEs7dBZy7YMEHIUhyb8pzvYNLI7shO/9aUW95xeDxhxPaUsqJnlu3pYgemM0UMR7bPP+3aBuYQWw0o54Do8If5l28u5D46II5QZAqRKIetvJGMOi2LBh1Ai/b+8J01eQEd9iVHqqbqqSXaOtKI18Y4T8xClkafWB2BTx+faBdiHL/h+KtQY83vEUif1bLVA/WZ/sg+Ow1b9AcyMXJs1o=

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.4")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
This feature enables an implementing class to redeliver messages that failed to
process within the defined timeout. In some cases, this might be desirable, but
it presents the risk of creating infinite loops.